### PR TITLE
store the actual block in the tree nodes

### DIFF
--- a/chaintree/chaintree.go
+++ b/chaintree/chaintree.go
@@ -311,6 +311,7 @@ func (ct *ChainTree) ProcessBlock(blockWithHeaders *BlockWithHeaders) (valid boo
 			return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error, tip must be either current tip or same previousTip as last ChainEntry, tip: %v endMap: %v, rootNode: %v", tip, lastEntry.PreviousTip, unmarshaledRoot.Node.Cid())}
 		}
 	}
+	ct.Dag.AddNodes(wrappedBlock)
 
 	ct.Dag.Prune()
 

--- a/chaintree/chaintree_test.go
+++ b/chaintree/chaintree_test.go
@@ -313,6 +313,10 @@ func TestBlockProcessing(t *testing.T) {
 
 		if test.shouldValid {
 			assert.True(t, valid, test.description)
+			wrappedBlock := sw.WrapObject(test.block)
+			assert.Nil(t, sw.Err, test.description)
+			node := tree.Dag.Get(wrappedBlock.Cid())
+			assert.NotNil(t, node, test.description)
 		}
 
 		if test.validator != nil {


### PR DESCRIPTION
Noticed this while working on a wallet... the block itself is never added to the nodes of the chain tree, so if you try to get the node, it's nil and errors. This just adds that block (if valid) to the nodes of the chaintree.