### PR TITLE
Remove unexecutable tree tip setting code

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -416,10 +416,6 @@ func (bt *BidirectionalTree) Swap(oldCid *cid.Cid, newNode *cbornode.Node) error
 			cbornode.DecodeInto(newParentNode.RawData(), &obj)
 			//spew.Dump(obj)
 
-			if parent.Node.Cid() == bt.Tip {
-				bt.Tip = newParentNode.Cid()
-			}
-
 			bt.Swap(parent.Node.Cid(), newParentNode)
 		}
 	}


### PR DESCRIPTION
@tobowers you had mentioned removing 1 of the 2 blocks here, I think this one since you can pass in the tree root to swap?

This code right now is a noop because `parent.Node.Cid() == bt.Tip` is never true, the syntax necessary for checking cid equality is `parent.Node.Cid().Equals(bt.Tip)` or something like `bt.Tip.KeyString() == oldCid.KeyString()`. Because this function calls swap anyways on https://github.com/QuorumControl/chaintree/commit/98f91cfac16418a4670069ba6826c774be2e9126#diff-59444efa5d0e1828731f7058a88b34dbL423, we can just let this boil up to [line 386](https://github.com/QuorumControl/chaintree/commit/98f91cfac16418a4670069ba6826c774be2e9126#diff-59444efa5d0e1828731f7058a88b34dbL386) which will modify the root tip.