### PR TITLE
Restrict values that can be set on a node

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -135,6 +135,17 @@ func (d *Dag) SetAsLink(pathAndKey []string, val interface{}) (*Dag, error) {
 }
 
 func (d *Dag) set(pathAndKey []string, val interface{}, asLink bool) (*Dag, error) {
+	if !asLink {
+		switch val.(type) {
+		// These are the built in type of go (excluding map) plus cid.Cid
+		// Use SetAsLink if attempting to set map
+		case bool, byte, complex64, complex128, error, float32, float64, int, int8, int16, int32, int64, string, uint, uint16, uint32, uint64, uintptr, cid.Cid, *bool, *byte, *complex64, *complex128, *error, *float32, *float64, *int, *int8, *int16, *int32, *int64, *string, *uint, *uint16, *uint32, *uint64, *uintptr, *cid.Cid, []bool, []byte, []complex64, []complex128, []error, []float32, []float64, []int, []int8, []int16, []int32, []int64, []string, []uint, []uint16, []uint32, []uint64, []uintptr, []cid.Cid, []*bool, []*byte, []*complex64, []*complex128, []*error, []*float32, []*float64, []*int, []*int8, []*int16, []*int32, []*int64, []*string, []*uint, []*uint16, []*uint32, []*uint64, []*uintptr, []*cid.Cid:
+			// Noop here, its a valid type, continue on
+		default:
+			return nil, fmt.Errorf("can not set complex objects, use asLink=true: %v", val)
+		}
+	}
+
 	var path []string
 	var key string
 

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -134,6 +134,31 @@ func TestDagSetAsLink(t *testing.T) {
 	assert.Equal(t, true, val)
 }
 
+func TestDagInvalidSet(t *testing.T) {
+	sw := &safewrap.SafeWrap{}
+
+	child := sw.WrapObject(map[string]interface{}{
+		"name": "child",
+	})
+
+	root := sw.WrapObject(map[string]interface{}{
+		"child": child.Cid(),
+	})
+
+	assert.Nil(t, sw.Err)
+
+	store := nodestore.NewStorageBasedStore(storage.NewMemStorage())
+	dag, err := NewDagWithNodes(store, root, child)
+	require.Nil(t, err)
+
+	dag, err = dag.Set([]string{"test"}, map[string]interface{}{
+		"child1": "1",
+		"child2": "2",
+	})
+
+	assert.NotNil(t, err)
+}
+
 func TestDagGet(t *testing.T) {
 	sw := &safewrap.SafeWrap{}
 


### PR DESCRIPTION
This is a bit ugly, but was the least objectionable path for now.

This is guard to ensure that complex types, such as map can't be
set with a key inside the dag. By limiting the values to basic
primitive types, arrays of those primitive types, and cids, we can keep
the modification of data inside a node fairly simple - otherwise we
would be tackling traversing inside a node up & down its nested maps.
Setting maps can easily be achieved with `SetAsLink`, which creates the
map as a new node with a referential cid in the parent.