### PR TITLE
Fix setting initial nested path with asLink=bool

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -165,7 +165,15 @@ func (d *Dag) set(pathAndKey []string, val interface{}, asLink bool) (*Dag, erro
 		return nil, fmt.Errorf("error resolving")
 	}
 	if existing == nil {
-		newObj := map[string]interface{}{key: val}
+		var newObj interface{}
+
+		if asLink {
+			path = append(path, key)
+			newObj = val
+		} else {
+			newObj = map[string]interface{}{key: val}
+		}
+
 		sw := &safewrap.SafeWrap{}
 		wrapped := sw.WrapObject(newObj)
 		if sw.Err != nil {

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -125,13 +125,23 @@ func TestDagSetAsLink(t *testing.T) {
 	dag, err := NewDagWithNodes(store, root, child)
 	require.Nil(t, err)
 
-	dag, err = dag.SetAsLink([]string{"child", "key"}, unlinked)
+	dag, err = dag.SetAsLink([]string{"child", "grandchild", "key"}, unlinked)
 	assert.Nil(t, err)
-
-	val, _, err := dag.Resolve([]string{"child", "key", "unlinked"})
+	val, _, err := dag.Resolve([]string{"child", "grandchild", "key", "unlinked"})
 
 	assert.Nil(t, err)
 	assert.Equal(t, true, val)
+
+	unlinked2 := map[string]interface{}{
+		"unlinked2": false,
+	}
+
+	dag, err = dag.SetAsLink([]string{"child", "grandchild", "key", "unlinkedsibling"}, unlinked2)
+	assert.Nil(t, err)
+
+	val, _, err = dag.Resolve([]string{"child", "grandchild", "key", "unlinkedsibling", "unlinked2"})
+	assert.Nil(t, err)
+	assert.Equal(t, false, val)
 }
 
 func TestDagInvalidSet(t *testing.T) {


### PR DESCRIPTION
Previously if you try an set something as link where there is no parent exists yet, the `existing` catch below would create a nested object `{key: val}`, which causes future attribute setting to fail (same reason we are only allowing those basic types for set).  So this updates the case when existing is nil, and asLink is true to correctly (I *think*) build up the full link path and set the data to the explicitly passed in object.