### PR TITLE
Fix nil error return on failed WrapObject

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -177,7 +177,7 @@ func (d *Dag) set(pathAndKey []string, val interface{}, asLink bool) (*Dag, erro
 		sw := &safewrap.SafeWrap{}
 		wrapped := sw.WrapObject(newObj)
 		if sw.Err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error wrapping (%v): %v", newObj, sw.Err)
 		}
 		err = d.store.StoreNode(wrapped)
 		if err != nil {
@@ -189,7 +189,7 @@ func (d *Dag) set(pathAndKey []string, val interface{}, asLink bool) (*Dag, erro
 	sw := &safewrap.SafeWrap{}
 	existingCbor := sw.WrapObject(existing)
 	if sw.Err != nil {
-		return nil, fmt.Errorf("error wrapping (%v): %v", existing, err)
+		return nil, fmt.Errorf("error wrapping (%v): %v", existing, sw.Err)
 	}
 
 	if asLink {


### PR DESCRIPTION
Currently if you pass an "unwrappable" val to `SetAsLink` on a new path, the error is being returned as nil instead of the actual error. This can lead to a memory panic (and buries the actual error) because the calling code is most likely checking `if err != nil` on the response from `SetAsLink`, which allows it to continue in its execution.