### PR TITLE
Pin go-ipld-cbor to commit (branch was deleted)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,7 +66,6 @@
   revision = "9ed527918c2f20abdf0adfab0553cd87db34f656"
 
 [[projects]]
-  branch = "refmt"
   digest = "1:8e5c84ed3786865c04c554a00deea1cc52d218dea8da596223bea99cd0727526"
   name = "github.com/ipfs/go-ipld-cbor"
   packages = ["."]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,6 @@
 [[constraint]]
   name = "github.com/multiformats/go-multihash"
   branch = "master"
-
 [[constraint]]
   name = "github.com/ipfs/go-ipld-cbor"
-  branch = "refmt"
+  revision = "8b666bca090899848849a507a008080db0fcfe21"


### PR DESCRIPTION
Newest `go-ipld-cbor` has breaking changes passing cid.Cid by value instead of pointer, so upgrade there is a big lift at the moment. So for now, this just pins to the commit that the old branch pointed to.