### PR TITLE
Fix corrupt tree updates

### DIFF
--- a/chaintree/chaintree.go
+++ b/chaintree/chaintree.go
@@ -184,7 +184,7 @@ func (ct *ChainTree) ProcessBlock(blockWithHeaders *BlockWithHeaders) (valid boo
 
 	unmarshaledTreeTip, err := newTree.Get(newTree.Tip)
 	if err != nil {
-		return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error getting new tree root: %v", err)}
+		return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error getting new tree tip: %v", err)}
 	}
 	newTreeMap := make(map[string]interface{})
 	err = cbornode.DecodeInto(unmarshaledTreeTip.RawData(), &newTreeMap)


### PR DESCRIPTION
This seems to fix the problem in the [chaintree set data bug card](https://trello.com/c/NcRs5Nu5), and the test @tobowers added for that now passes (with a small fix to the test that I _think_ was what @tobowers intended to write anyway).

However, a gossip3/actors test now fails on this branch in a way that it is pretty strange (to me). [Here's a transcript of that test failure](https://gist.github.com/cap10morgan/700c9597b66e20548473b5d14dbb1fca).