### PR TITLE
Improve output of dag/Dump

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -2,6 +2,7 @@ package dag
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	cid "github.com/ipfs/go-cid"
@@ -299,17 +300,22 @@ func (d *Dag) Dump() string {
 	nodes, _ := d.Nodes()
 	nodeStrings := make([]string, len(nodes))
 	for i, node := range nodes {
-		nodeStrings[i] = node.Cid().String()
+		nodeJSON, err := node.MarshalJSON()
+		if err != nil {
+			fmt.Errorf("error marshalling JSON for node %v: %v", node, err)
+		}
+		nodeStrings[i] = fmt.Sprintf("%v : %v", node.Cid().String(), string(nodeJSON))
 	}
 	return fmt.Sprintf(`
 Tip: %s,
 Tree:	
 %s
 
-Nodes: %v
+Nodes:
+%v
 
 	`,
 		d.Tip.String(),
 		spew.Sdump(d.dumpNode(rootNode, false)),
-		nodes)
+		strings.Join(nodeStrings, "\n\n"))
 }


### PR DESCRIPTION
I was having a hard time making use of the previous version of this function, so after @brandonwestcott showed me how to get the JSON format of the nodes I figured I'd see if folks wanted that in here. So now it outputs the nodes as `cid : json` with a blank line between each.

After this change the output looks something like this:

```
Tip: zdpuAoRyFcL6tBgxAuDsZ5356C4KUjY3Q5PHoqhgV5YrShvDw,
Tree:
(map[string]interface {}) (len=3) {
 (string) (len=2) "id": (string) (len=53) "did:tupelo:0xc69B167e38350F1Ae51b3d5468842aDb8A15e6E8",
 (string) (len=4) "tree": (cid.Cid) zdpuB2CuKn9JfvEnKnx2B3gQxwENvYi6dTYcQXMC1nsewvUjw,
 (string) (len=5) "chain": (cid.Cid) zdpuAy2vZzoRvTFgE4qMg8L1WsykhF1iuSUVfLWx84LuStFKh
}


Nodes:
zdpuAoRyFcL6tBgxAuDsZ5356C4KUjY3Q5PHoqhgV5YrShvDw : {"chain":{"/":"zdpuAy2vZzoRvTFgE4qMg8L1WsykhF1iuSUVfLWx84LuStFKh"},"id":"did:tupelo:0xc69B167e38350F1Ae51b3d5468842aDb8A15e6E8","tree":{"/":"zdpuB2CuKn9JfvEnKnx2B3gQxwENvYi6dTYcQXMC1nsewvUjw"}}

zdpuAy2vZzoRvTFgE4qMg8L1WsykhF1iuSUVfLWx84LuStFKh : {"end":{"/":"zdpuAynXohasV5YEhgorXwNXohasXyK5FuP9pZGquX3pc8Zy3"},"genesis":null}

zdpuAynXohasV5YEhgorXwNXohasXyK5FuP9pZGquX3pc8Zy3 : {"blocksWithHeaders":[{"/":"zdpuArD4HHrkW52UABKomj6fwJwVkTehBFWm5rAG89ybWxmtt"}],"previous":{"/":"zdpuAodJ9tBcHftWAgBwYryx9i5Xh51gMdvYT5MqPFnsw19Yc"},"previousTip":"zdpuB24qcjuc8zkBqDfXTWh7NSArmeJ1YVZrYKr1vHpYo3rSP"}

zdpuAodJ9tBcHftWAgBwYryx9i5Xh51gMdvYT5MqPFnsw19Yc : {"blocksWithHeaders":[{"/":"zdpuAsFsk2yAU4HXRBDkWz4bAnajp7pRoYVQJ8M54yuGwAAPF"}],"previous":{"/":"zdpuAyYskwffouQTykmELoRpY7Vrh9jKQgeqmw6paYGvj8r5o"},"previousTip":"zdpuAmh2pZMzmAGYMqSLZ1YNpkJfoSVeR6tW5NP5U8pfgHmKL"}

zdpuAyYskwffouQTykmELoRpY7Vrh9jKQgeqmw6paYGvj8r5o : {"blocksWithHeaders":[{"/":"zdpuAqAhWJJoudowGnsJTE6pyUFye86Z7kTdSaGSpn63LneQW"}],"previous":null}

zdpuAqAhWJJoudowGnsJTE6pyUFye86Z7kTdSaGSpn63LneQW : {"headers":{"signatures":{"0xc69B167e38350F1Ae51b3d5468842aDb8A15e6E8":{"signature":"OV3LuWDYwqRzVlXcOnrJRgSglymIHFhIV1x6bLwUlHlQ97+rtboUbpcBF1Gt/g5JG+hTGZlQc8pObUGMcNM1hgA=","type":"secp256k1"}}},"transactions":[{"payload":{"path":"some/data","value":"is now set"},"type":"SET_DATA"}]}

zdpuAsFsk2yAU4HXRBDkWz4bAnajp7pRoYVQJ8M54yuGwAAPF : {"headers":{"signatures":{"0xc69B167e38350F1Ae51b3d5468842aDb8A15e6E8":{"signature":"njLlhYoeqHDvTMa31biELU4ZORc313IIHeFqAg3WRwN7bxiIDuDKt+q8yYCnvBj6sVrYkv45pOnH+9haUlorBQE=","type":"secp256k1"}}},"previousTip":"zdpuB3RHXq4yN6wzGWgTKsAyuBFwDHzvbUZZQukKzjy7BgTXs","transactions":[{"payload":{"path":"some/more/data","value":"is also here"},"type":"SET_DATA"}]}

zdpuArD4HHrkW52UABKomj6fwJwVkTehBFWm5rAG89ybWxmtt : {"headers":{"signatures":{"0xc69B167e38350F1Ae51b3d5468842aDb8A15e6E8":{"signature":"e7ZT9toNoBsdikJp0e9JSbqqDjMEUsZLDdti017L9SI4KVa9jdDQn7lJDOJzYVf0v/m22Zian2PNyfPZOcmhfAE=","type":"secp256k1"}}},"previousTip":"zdpuAoizeamhFCz2fLvWbvnw3DyqETv1Mj3MocWHewa579Zcq","transactions":[{"payload":{"path":"and/thisotherthing","value":{"foo":42}},"type":"SET_DATA"}]}

zdpuB2CuKn9JfvEnKnx2B3gQxwENvYi6dTYcQXMC1nsewvUjw : {"and":{"/":"zdpuB2U9bpbgkpe8WCD7511vZh2KLWGpY1NNZriqWmvNGetcB"},"some":{"/":"zdpuAvfkJvVAtwd4SrJ1yX79vD2MHGuoXvkcDeggUgW3UT57m"}}

zdpuB2U9bpbgkpe8WCD7511vZh2KLWGpY1NNZriqWmvNGetcB : {"thisotherthing":{"/":"zdpuAya9JbazEzQuQBYNEYhsu1caKnh8tUE4Luvwo9BBy7yKg"}}

zdpuAya9JbazEzQuQBYNEYhsu1caKnh8tUE4Luvwo9BBy7yKg : {"foo":42}

zdpuAvfkJvVAtwd4SrJ1yX79vD2MHGuoXvkcDeggUgW3UT57m : {"data":"is now set","more":{"/":"zdpuB3EQuDkU5Wh2aTMUwP5UnbCwUdcUdvWDrTiPrML9jkSsT"}}

zdpuB3EQuDkU5Wh2aTMUwP5UnbCwUdcUdvWDrTiPrML9jkSsT : {"data":"is also here"}
```