### PR TITLE
Make ipld store adapter support either disk access or http

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
   digest = "1:1779bbb6256073e58fa31c8989a96775062336b7c37e55b27cc9c8f0890995bb"
   name = "github.com/bifurcation/mint"
   packages = [
@@ -74,6 +82,14 @@
   pruneopts = "UT"
   revision = "d2cf3cdd35ce0d789056c4bc02a4d6349c947caf"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:94cad6e2359d57da6652e689189c5b6ef19f99db6304d2c41de54f6632e15143"
+  name = "github.com/cheggaaa/pb"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1cc5bbe20449079337944d56292c7383510c534c"
+  version = "v1.0.27"
 
 [[projects]]
   digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
@@ -128,6 +144,14 @@
   pruneopts = "UT"
   revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:fffcae02150ef80950d18c721eaa249e6e80df5e0b9b645731949e586573f685"
+  name = "github.com/elgris/jsondiff"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "765b5c24c302e7c7fd032fdb8c69f101918229cb"
 
 [[projects]]
   branch = "master"
@@ -266,6 +290,14 @@
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:1bf41eac472b0992dccaf533d339c7a139558e1bd4ec1a1c4b5d23c8a67c81fb"
+  name = "github.com/ipfs/go-ipfs-http-client"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "984004a746c6b66a07839f2925ed79345dd8e67f"
+  source = "github.com/quorumcontrol/ipsn-go-ipfs-http-client"
+
+[[projects]]
   digest = "1:aae82c244bd91107575a0244a29e82e34ba23e06b6892557e33728de48deba96"
   name = "github.com/ipfs/go-ipfs-util"
   packages = ["."]
@@ -291,17 +323,24 @@
   revision = "b2d848bada9dbd11ec27b9a38e8726555e249fd4"
 
 [[projects]]
-  digest = "1:36f721d7ad30c52efade27d8307ea302434145b6e4f4116e2a8adc9270db1515"
+  digest = "1:86a1fdefa74b791b6bc35754bc66265662a85202dbc2889b9464da31163b42c1"
   name = "github.com/ipsn/go-ipfs"
   packages = [
     ".",
+    "assets",
     "blocks/blockstoreutil",
     "commands",
     "core",
+    "core/commands",
+    "core/commands/cmdenv",
+    "core/commands/dag",
+    "core/commands/e",
+    "core/commands/name",
+    "core/commands/object",
+    "core/commands/unixfs",
     "core/coreapi",
-    "core/coreapi/interface",
-    "core/coreapi/interface/options",
     "core/coredag",
+    "core/corehttp",
     "core/corerepo",
     "core/coreunix",
     "core/mock",
@@ -309,13 +348,18 @@
     "exchange/reprovide",
     "filestore",
     "filestore/pb",
+    "fuse/ipns",
     "fuse/mount",
+    "fuse/node",
+    "fuse/readonly",
     "gxlibs/github.com/Kubuxu/go-os-helper",
     "gxlibs/github.com/Stebalien/go-bitfield",
-    "gxlibs/github.com/gxed/GoEndian",
-    "gxlibs/github.com/gxed/eventfd",
+    "gxlibs/github.com/blang/semver",
     "gxlibs/github.com/gxed/pubsub",
+    "gxlibs/github.com/hsanjuan/go-libp2p-gostream",
+    "gxlibs/github.com/hsanjuan/go-libp2p-http",
     "gxlibs/github.com/ipfs/bbloom",
+    "gxlibs/github.com/ipfs/dir-index-html",
     "gxlibs/github.com/ipfs/go-bitswap",
     "gxlibs/github.com/ipfs/go-bitswap/decision",
     "gxlibs/github.com/ipfs/go-bitswap/getter",
@@ -325,6 +369,7 @@
     "gxlibs/github.com/ipfs/go-bitswap/network",
     "gxlibs/github.com/ipfs/go-bitswap/notifications",
     "gxlibs/github.com/ipfs/go-bitswap/peermanager",
+    "gxlibs/github.com/ipfs/go-bitswap/providerquerymanager",
     "gxlibs/github.com/ipfs/go-bitswap/session",
     "gxlibs/github.com/ipfs/go-bitswap/sessionmanager",
     "gxlibs/github.com/ipfs/go-bitswap/sessionpeermanager",
@@ -336,6 +381,7 @@
     "gxlibs/github.com/ipfs/go-blockservice",
     "gxlibs/github.com/ipfs/go-cid",
     "gxlibs/github.com/ipfs/go-cidutil",
+    "gxlibs/github.com/ipfs/go-cidutil/cidenc",
     "gxlibs/github.com/ipfs/go-datastore",
     "gxlibs/github.com/ipfs/go-datastore/autobatch",
     "gxlibs/github.com/ipfs/go-datastore/delayed",
@@ -355,7 +401,7 @@
     "gxlibs/github.com/ipfs/go-ipfs-chunker",
     "gxlibs/github.com/ipfs/go-ipfs-cmdkit",
     "gxlibs/github.com/ipfs/go-ipfs-cmds",
-    "gxlibs/github.com/ipfs/go-ipfs-cmds/debug",
+    "gxlibs/github.com/ipfs/go-ipfs-cmds/http",
     "gxlibs/github.com/ipfs/go-ipfs-config",
     "gxlibs/github.com/ipfs/go-ipfs-config/serialize",
     "gxlibs/github.com/ipfs/go-ipfs-delay",
@@ -389,7 +435,9 @@
     "gxlibs/github.com/ipfs/go-path/resolver",
     "gxlibs/github.com/ipfs/go-todocounter",
     "gxlibs/github.com/ipfs/go-unixfs",
+    "gxlibs/github.com/ipfs/go-unixfs/file",
     "gxlibs/github.com/ipfs/go-unixfs/hamt",
+    "gxlibs/github.com/ipfs/go-unixfs/importer",
     "gxlibs/github.com/ipfs/go-unixfs/importer/balanced",
     "gxlibs/github.com/ipfs/go-unixfs/importer/helpers",
     "gxlibs/github.com/ipfs/go-unixfs/importer/trickle",
@@ -397,6 +445,9 @@
     "gxlibs/github.com/ipfs/go-unixfs/mod",
     "gxlibs/github.com/ipfs/go-unixfs/pb",
     "gxlibs/github.com/ipfs/go-verifcid",
+    "gxlibs/github.com/ipfs/interface-go-ipfs-core",
+    "gxlibs/github.com/ipfs/interface-go-ipfs-core/options",
+    "gxlibs/github.com/ipfs/interface-go-ipfs-core/options/namesys",
     "gxlibs/github.com/jbenet/goprocess",
     "gxlibs/github.com/jbenet/goprocess/context",
     "gxlibs/github.com/jbenet/goprocess/periodic",
@@ -468,9 +519,6 @@
     "gxlibs/github.com/libp2p/go-msgio",
     "gxlibs/github.com/libp2p/go-reuseport",
     "gxlibs/github.com/libp2p/go-reuseport-transport",
-    "gxlibs/github.com/libp2p/go-reuseport/poll",
-    "gxlibs/github.com/libp2p/go-reuseport/singlepoll",
-    "gxlibs/github.com/libp2p/go-sockaddr/net",
     "gxlibs/github.com/libp2p/go-stream-muxer",
     "gxlibs/github.com/libp2p/go-tcp-transport",
     "gxlibs/github.com/libp2p/go-testutil",
@@ -517,14 +565,15 @@
     "gxlibs/github.com/whyrusleeping/go-smux-multiplex",
     "gxlibs/github.com/whyrusleeping/go-smux-multistream",
     "gxlibs/github.com/whyrusleeping/go-smux-yamux",
+    "gxlibs/github.com/whyrusleeping/go-sysinfo",
     "gxlibs/github.com/whyrusleeping/mafmt",
     "gxlibs/github.com/whyrusleeping/mdns",
     "gxlibs/github.com/whyrusleeping/multiaddr-filter",
+    "gxlibs/github.com/whyrusleeping/tar-utils",
     "gxlibs/github.com/whyrusleeping/timecache",
     "gxlibs/github.com/whyrusleeping/yamux",
     "keystore",
     "namesys",
-    "namesys/opts",
     "namesys/republisher",
     "p2p",
     "pin",
@@ -540,13 +589,14 @@
     "repo/common",
     "repo/fsrepo",
     "repo/fsrepo/migrations",
+    "tar",
     "thirdparty/cidv0v1",
     "thirdparty/dir",
     "thirdparty/math2",
     "thirdparty/verifbs",
   ]
   pruneopts = "UT"
-  revision = "4b3ab38e3ef37ded722bab7ee9f3c4cf69fbaeff"
+  revision = "30b2b298240fb29ae96ebc1dce5c7ce6f541bf78"
 
 [[projects]]
   digest = "1:b352ae8b1a77cc6b48fc8e314e34a522cfc76d6ca3a06c93b29c9cde5de6771e"
@@ -621,6 +671,30 @@
   version = "v0.0.4"
 
 [[projects]]
+  digest = "1:0356f3312c9bd1cbeda81505b7fd437501d8e778ab66998ef69f00d7f9b3a0d7"
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3ee7d812e62a0804a7d0a324e0249ca2db3476d3"
+  version = "v0.0.4"
+
+[[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2b32af4d2a529083275afc192d1067d8126b578c7a9613b26600e4df9c735155"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
+
+[[projects]]
   digest = "1:d64a0aa67f715fd28f5ddfe0d74c06b6d6fe0fed931d77e662f2c4694f6854dc"
   name = "github.com/miekg/dns"
   packages = ["."]
@@ -674,7 +748,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "8be2a682ab9f254311de1375145a2f78a809b07d"
-  version = "v1.0.8"
 
 [[projects]]
   digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
@@ -720,6 +793,52 @@
   revision = "8b1e46de349b0c099d425ed8fddee3ff6eff3eef"
 
 [[projects]]
+  digest = "1:93a746f1060a8acbcf69344862b2ceced80f854170e1caae089b2834c5fbf7f4"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
+
+[[projects]]
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
+  version = "v0.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ca30ee2c96d195cef49b546d10825d3e13b50c63da4df23c80e77c51e07bad0d"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "iostats",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "6ed1f7e1041181781dd2826d3001075d011a80cc"
+
+[[projects]]
   branch = "master"
   digest = "1:32e760f00b355161f1c67a6fc91ae3b3d5baacb94682a3d7b45aeeecd0d7a2f5"
   name = "github.com/quorumcontrol/namedlocker"
@@ -735,6 +854,14 @@
   revision = "c5e9df97b7f4aa63a9de7f3c30405f5acac9b4d9"
   source = "git@github.com:quorumcontrol/storage.git"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
+  name = "github.com/rs/cors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
@@ -887,16 +1014,21 @@
   input-imports = [
     "github.com/davecgh/go-spew/spew",
     "github.com/ipfs/go-cid",
+    "github.com/ipfs/go-ipfs-http-client",
     "github.com/ipfs/go-ipld-cbor",
     "github.com/ipfs/go-ipld-format",
+    "github.com/ipsn/go-ipfs/commands",
     "github.com/ipsn/go-ipfs/core",
     "github.com/ipsn/go-ipfs/core/coreapi",
-    "github.com/ipsn/go-ipfs/core/coreapi/interface",
-    "github.com/ipsn/go-ipfs/core/coreapi/interface/options",
+    "github.com/ipsn/go-ipfs/core/corehttp",
     "github.com/ipsn/go-ipfs/core/mock",
     "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-cid",
+    "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipfs-config",
     "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipld-cbor",
     "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipld-format",
+    "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/interface-go-ipfs-core",
+    "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/interface-go-ipfs-core/options",
+    "github.com/ipsn/go-ipfs/gxlibs/github.com/multiformats/go-multiaddr",
     "github.com/multiformats/go-multihash",
     "github.com/polydawn/refmt/obj",
     "github.com/polydawn/refmt/obj/atlas",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "github.com/ipsn/go-ipfs"
-  revision = "4b3ab38e3ef37ded722bab7ee9f3c4cf69fbaeff"
+  revision = "30b2b298240fb29ae96ebc1dce5c7ce6f541bf78"
 
 [[constraint]]
   name = "github.com/ipfs/go-ipld-format"
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/multiformats/go-multihash"
-  version = "1.0.8"
+  revision = "8be2a682ab9f254311de1375145a2f78a809b07d"
 
 [[constraint]]
   name = "github.com/polydawn/refmt"
@@ -65,6 +65,11 @@
   source = "git@github.com:quorumcontrol/storage.git"
   name = "github.com/quorumcontrol/storage"
   version = "1.1.1"
+
+[[override]]
+  name = "github.com/ipfs/go-ipfs-http-client"
+  source = "github.com/quorumcontrol/ipsn-go-ipfs-http-client"
+  revision = "984004a746c6b66a07839f2925ed79345dd8e67f"
 
 [prune]
   go-tests = true

--- a/nodestore/ipld_store.go
+++ b/nodestore/ipld_store.go
@@ -1,53 +1,46 @@
 package nodestore
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
 
 	cid "github.com/ipfs/go-cid"
 	cbornode "github.com/ipfs/go-ipld-cbor"
-	"github.com/ipsn/go-ipfs/core"
-	"github.com/ipsn/go-ipfs/core/coreapi"
-	ipfsCoreApiIface "github.com/ipsn/go-ipfs/core/coreapi/interface"
-	ipfsCoreApiOpt "github.com/ipsn/go-ipfs/core/coreapi/interface/options"
 	ipsnCid "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-cid"
 	ipsnCbornode "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipld-cbor"
 	ipldFormat "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipld-format"
+	ipsnCoreApiIface "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/interface-go-ipfs-core"
+	ipsnCoreApiOpt "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/interface-go-ipfs-core/options"
+	multihash "github.com/multiformats/go-multihash"
 	"github.com/quorumcontrol/chaintree/safewrap"
 )
 
 // IpldStore is a NodeStore that uses IPLD
 type IpldStore struct {
-	node *core.IpfsNode
-	api  ipfsCoreApiIface.CoreAPI
+	api ipsnCoreApiIface.CoreAPI
 }
 
-// var _ NodeStore = (*IpldStore)(nil)
+var errNoSuchLink = ipsnCbornode.ErrNoSuchLink
 
-// NewIpldStore creates a new NodeStore using the store argument for the backend
-func NewIpldStore(node *core.IpfsNode) *IpldStore {
-	api, err := coreapi.NewCoreAPI(node)
-	if err != nil {
-		panic("Could not instantiate new core IPFS API")
-	}
+var _ NodeStore = (*IpldStore)(nil)
 
+// NewIpldStore creates a new NodeStore using an IPLD api
+func NewIpldStore(api ipsnCoreApiIface.CoreAPI) *IpldStore {
 	return &IpldStore{
-		node: node,
-		api:  api,
+		api: api,
 	}
 }
 
-func (ipld *IpldStore) dag() ipfsCoreApiIface.DagAPI {
+func (ipld *IpldStore) dag() ipsnCoreApiIface.APIDagService {
 	return ipld.api.Dag()
 }
 
-func (ipld *IpldStore) pin() ipfsCoreApiIface.PinAPI {
+func (ipld *IpldStore) pin() ipsnCoreApiIface.PinAPI {
 	return ipld.api.Pin()
 }
 
-func (ipld *IpldStore) block() ipfsCoreApiIface.BlockAPI {
+func (ipld *IpldStore) block() ipsnCoreApiIface.BlockAPI {
 	return ipld.api.Block()
 }
 
@@ -71,11 +64,11 @@ func (ipld *IpldStore) CreateNodeFromBytes(data []byte) (node *cbornode.Node, er
 }
 
 // GetNode returns a cbornode for a CID
-func (ipld *IpldStore) GetNode(cid cid.Cid) (node *cbornode.Node, err error) {
+func (ipld *IpldStore) GetNode(nodeCid cid.Cid) (node *cbornode.Node, err error) {
 	ctx := context.Background()
-	castCid, _ := ipsnCid.Parse(cid.String())
+	castCid, _ := ipsnCid.Parse(nodeCid.String())
 
-	pins, err := ipld.pin().Ls(ctx, ipfsCoreApiOpt.Pin.Type.Direct())
+	pins, err := ipld.pin().Ls(ctx, ipsnCoreApiOpt.Pin.Type.Direct())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching pins: %v", err)
 	}
@@ -92,7 +85,7 @@ func (ipld *IpldStore) GetNode(cid cid.Cid) (node *cbornode.Node, err error) {
 		return nil, nil
 	}
 
-	dagNode, err := ipld.dag().Get(ctx, ipfsCoreApiIface.IpldPath(castCid))
+	dagNode, err := ipld.dag().Get(ctx, castCid)
 
 	if err == ipldFormat.ErrNotFound {
 		return nil, nil
@@ -114,13 +107,15 @@ func (ipld *IpldStore) GetNode(cid cid.Cid) (node *cbornode.Node, err error) {
 func (ipld *IpldStore) DeleteNode(nodeCid cid.Cid) error {
 	ctx := context.Background()
 	castCid, _ := ipsnCid.Parse(nodeCid.String())
-	err := ipld.node.Pinning.Unpin(ctx, castCid, false)
+	path := ipsnCoreApiIface.IpldPath(castCid)
+
+	err := ipld.pin().Rm(ctx, path, ipsnCoreApiOpt.Pin.RmRecursive(false))
 
 	if err != nil {
 		return fmt.Errorf("error unpinning cid %s: %v", nodeCid.String(), err)
 	}
 
-	err = ipld.block().Rm(ctx, ipfsCoreApiIface.IpldPath(castCid))
+	err = ipld.block().Rm(ctx, ipsnCoreApiIface.IpldPath(castCid))
 	if err != nil {
 		return fmt.Errorf("error removing block cid %s: %v", nodeCid.String(), err)
 	}
@@ -149,9 +144,9 @@ func (ipld *IpldStore) DeleteTree(tip cid.Cid) error {
 func (ipld *IpldStore) resolveNode(tip cid.Cid, path []string) (ipldFormat.Node, []string, error) {
 	ctx := context.Background()
 	castCid, _ := ipsnCid.Parse(tip.String())
-	resolvedPath, err := ipld.api.ResolvePath(ctx, ipfsCoreApiIface.Join(ipfsCoreApiIface.IpldPath(castCid), path...))
+	resolvedPath, err := ipld.api.ResolvePath(ctx, ipsnCoreApiIface.Join(ipsnCoreApiIface.IpldPath(castCid), path...))
 
-	if err == ipsnCbornode.ErrNoSuchLink && len(path) > 0 {
+	if err != nil && err.Error() == errNoSuchLink.Error() && len(path) > 0 {
 		parentPath := path[:len(path)-1]
 		parentNode, parentRemainder, parentErr := ipld.resolveNode(tip, parentPath)
 		return parentNode, append(parentRemainder, path[len(parentPath):]...), parentErr
@@ -179,17 +174,12 @@ func (ipld *IpldStore) resolveNode(tip cid.Cid, path []string) (ipldFormat.Node,
 func (ipld *IpldStore) Resolve(tip cid.Cid, path []string) (interface{}, []string, error) {
 	dagNode, dagRemaining, err := ipld.resolveNode(tip, path)
 
-	if err == ipsnCbornode.ErrNoSuchLink {
-		return nil, dagRemaining, nil
-	}
-
 	if err != nil {
 		return nil, dagRemaining, nil
 	}
-
 	nodeValue, remaining, err := dagNode.Resolve(dagRemaining)
 
-	if err == ipsnCbornode.ErrNoSuchLink {
+	if err != nil && err.Error() == errNoSuchLink.Error() {
 		return nil, dagRemaining, nil
 	}
 
@@ -203,13 +193,21 @@ func (ipld *IpldStore) Resolve(tip cid.Cid, path []string) (interface{}, []strin
 // StoreNode implements the NodeStore interface
 func (ipld *IpldStore) StoreNode(node *cbornode.Node) error {
 	nodeCid := node.Cid()
+	castCid, _ := ipsnCid.Parse(nodeCid.String())
+	path := ipsnCoreApiIface.IpldPath(castCid)
 	ctx := context.Background()
-	path, err := ipld.dag().Put(ctx, bytes.NewReader(node.RawData()), ipfsCoreApiOpt.Dag.InputEnc("cbor"))
+
+	ipsnNode, err := ipsnCbornode.Decode(node.RawData(), multihash.SHA2_256, -1)
+	if err != nil {
+		return fmt.Errorf("error decoding %v err: %v", nodeCid.String(), err)
+	}
+
+	err = ipld.dag().Add(ctx, ipsnNode)
 	if err != nil {
 		return fmt.Errorf("error putting key %v err: %v", nodeCid.String(), err)
 	}
 
-	err = ipld.pin().Add(ctx, path, ipfsCoreApiOpt.Pin.Recursive(false))
+	err = ipld.pin().Add(ctx, path, ipsnCoreApiOpt.Pin.Recursive(false))
 	if err != nil {
 		return fmt.Errorf("error pinning key %v err: %v", nodeCid.String(), err)
 	}

--- a/nodestore/ipld_store_test.go
+++ b/nodestore/ipld_store_test.go
@@ -1,15 +1,83 @@
 package nodestore
 
 import (
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
+	ipfsHttpClient "github.com/ipfs/go-ipfs-http-client"
+	"github.com/ipsn/go-ipfs/commands"
+	"github.com/ipsn/go-ipfs/core"
+	"github.com/ipsn/go-ipfs/core/coreapi"
+	corehttp "github.com/ipsn/go-ipfs/core/corehttp"
 	coremock "github.com/ipsn/go-ipfs/core/mock"
+	config "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-ipfs-config"
+	ma "github.com/ipsn/go-ipfs/gxlibs/github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIpldBased(t *testing.T) {
 	node, err := coremock.NewMockNode()
 	require.Nil(t, err)
-	store := NewIpldStore(node)
+	api, err := coreapi.NewCoreAPI(node)
+	require.Nil(t, err)
+	store := NewIpldStore(api)
 	SubtestAll(t, store)
+}
+
+func TestIpldHttpBased(t *testing.T) {
+	node, err := coremock.NewMockNode()
+	require.Nil(t, err)
+	defer node.Close()
+
+	freePort, err := getFreePort()
+	require.Nil(t, err)
+
+	apiMaddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", freePort))
+	require.Nil(t, err)
+
+	cfg, err := node.Repo.Config()
+	require.Nil(t, err)
+
+	cfg.Addresses.API = []string{apiMaddr.String()}
+
+	cmdContext := commands.Context{
+		Online:     true,
+		ConfigRoot: "/tmp/.mockipfsconfig",
+		ReqLog:     &commands.ReqLog{},
+		LoadConfig: func(path string) (*config.Config, error) {
+			return cfg, nil
+		},
+		ConstructNode: func() (*core.IpfsNode, error) {
+			return node, nil
+		},
+	}
+
+	go func() {
+		err := corehttp.ListenAndServe(node, apiMaddr.String(), []corehttp.ServeOption{corehttp.CommandsOption(cmdContext)}...)
+		require.Nil(t, err)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	api, _ := ipfsHttpClient.NewApi(apiMaddr)
+
+	store := NewIpldStore(api)
+
+	SubtestAll(t, store)
+}
+
+func getFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
So I think this is both pretty awesome... and also slightly terrible.

This adjusts the `NewIpldStore` to accept any `CoreApi` interface from ipfs - primarily that means you can pass in either `ipfsHttpClient.NewApi(apiMaddr)` (ipfs over http) or `coreapi.NewCoreAPI(node)` (ipfs via program instantiated node). The big win is that we maintain only one set of logic and if in the future there are additional interfaces, this should just work.

You: "Wow, that sounds amazing @brandonwestcott"
Me: "Unfortunately because of interface definitions that exist due to using the ipsn versions of code, the only way I could get this to work is to fork the go client and ungx it: https://github.com/quorumcontrol/ipsn-go-ipfs-http-client - now its fairly simple to do that, more or less just https://github.com/ipsn/go-ipfs/blob/ungx/.travis.yml - but ew"

