### PR TITLE
Fix linting issues

### DIFF
--- a/chaintree/chaintree.go
+++ b/chaintree/chaintree.go
@@ -192,6 +192,9 @@ func (ct *ChainTree) ProcessBlock(blockWithHeaders *BlockWithHeaders) (valid boo
 	}
 
 	chainNode, err := ct.Dag.Get(*root.Chain)
+	if err != nil {
+		return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error getting node: %v", err)}
+	}
 	chain := &Chain{}
 	err = cbornode.DecodeInto(chainNode.RawData(), chain)
 	if err != nil {
@@ -235,6 +238,9 @@ func (ct *ChainTree) ProcessBlock(blockWithHeaders *BlockWithHeaders) (valid boo
 	// otherwise we have an existing chain in this chaintree
 
 	endNode, err := ct.Dag.Get(*chain.End)
+	if err != nil {
+		return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error getting end node: %v", err)}
+	}
 	if endNode == nil {
 		return false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("missing end node in chain tree")}
 	}

--- a/chaintree/chaintree_test.go
+++ b/chaintree/chaintree_test.go
@@ -265,7 +265,7 @@ func TestBuildingUpAChain(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, valid)
 
-	entry, _, err := tree.Dag.Resolve([]string{"chain", "end"})
+	_, _, err = tree.Dag.Resolve([]string{"chain", "end"})
 	require.Nil(t, err)
 	//assert.Equal(t, blockCid, entry.([]interface{})[0].(cid.Cid))
 
@@ -457,6 +457,7 @@ func BenchmarkEncodeDecode(b *testing.B) {
 			"SET_DATA": setData,
 		},
 	)
+	require.Nil(b, err)
 
 	block := &BlockWithHeaders{
 		Block: Block{

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/nodestore"
 )
 
@@ -166,9 +166,9 @@ func (d *Dag) getExisting(path []string) (val map[string]interface{}, remainingP
 		existing, _, _ = d.Resolve([]string{})
 	}
 
-	switch existing.(type) {
+	switch existing := existing.(type) {
 	case map[string]interface{}:
-		return existing.(map[string]interface{}), remaining, nil
+		return existing, remaining, nil
 	case nil:
 		// nil can be returned when an object exists at a part of the path, but the next
 		// segment of the path (a key in the object) does not exist.
@@ -309,7 +309,7 @@ func (d *Dag) Dump() string {
 	for i, node := range nodes {
 		nodeJSON, err := node.MarshalJSON()
 		if err != nil {
-			fmt.Errorf("error marshalling JSON for node %v: %v", node, err)
+			panic(fmt.Sprintf("error marshalling JSON for node %v: %v", node, err))
 		}
 		nodeStrings[i] = fmt.Sprintf("%v : %v", node.Cid().String(), string(nodeJSON))
 	}

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -80,7 +80,8 @@ func TestDagSet(t *testing.T) {
 	assert.Equal(t, "alice", val2)
 
 	// test works with a CID
-	dag.AddNodes(unlinked)
+	err = dag.AddNodes(unlinked)
+	require.Nil(t, err)
 
 	dag, err = dag.Set([]string{"test"}, unlinked.Cid())
 	assert.Nil(t, err)
@@ -108,6 +109,7 @@ func TestDagSet(t *testing.T) {
 
 	// original sibling is still available
 	val, _, err = dag.Resolve(path)
+	require.Nil(t, err)
 	assert.Equal(t, "bob", val)
 
 	siblingVal, _, err := dag.Resolve(siblingPath)
@@ -351,12 +353,11 @@ func TestDagInvalidSet(t *testing.T) {
 	dag, err := NewDagWithNodes(store, root, child)
 	require.Nil(t, err)
 
-	dag, err = dag.Set([]string{"test"}, map[string]interface{}{
+	_, err = dag.Set([]string{"test"}, map[string]interface{}{
 		"child1": "1",
 		"child2": "2",
 	})
-
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 }
 
 func TestDagGet(t *testing.T) {
@@ -429,6 +430,7 @@ func TestDagUpdate(t *testing.T) {
 	require.Nil(t, err)
 
 	dag, err = dag.Update([]string{"child1", "child2"}, map[string]interface{}{"name": "changed"})
+	require.Nil(t, err)
 
 	val, remain, err := dag.Resolve([]string{"child1", "child2", "name"})
 	require.Nil(t, err)

--- a/nodestore/interface_test.go
+++ b/nodestore/interface_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/safewrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,10 +33,10 @@ func SubtestInterfaceGetNode(t *testing.T, ns NodeStore) {
 	sw := &safewrap.SafeWrap{}
 	testNode := sw.WrapObject(obj)
 
-	ns.CreateNode(obj)
+	_, err := ns.CreateNode(obj)
+	require.Nil(t, err)
 
 	node, err := ns.GetNode(testNode.Cid())
-
 	require.Nil(t, err)
 	assert.Equal(t, testNode.Cid().String(), node.String())
 }
@@ -196,8 +196,10 @@ func SubtestInterfaceResolve(t *testing.T, ns NodeStore) {
 	})
 
 	assert.Nil(t, sw.Err)
-	ns.CreateNodeFromBytes(child.RawData())
-	ns.CreateNodeFromBytes(root.RawData())
+	_, err := ns.CreateNodeFromBytes(child.RawData())
+	require.Nil(t, err)
+	_, err = ns.CreateNodeFromBytes(root.RawData())
+	require.Nil(t, err)
 
 	// Resolves through the tree
 	val, remaining, err := ns.Resolve(root.Cid(), []string{"child", "name"})

--- a/nodestore/storagebased.go
+++ b/nodestore/storagebased.go
@@ -11,8 +11,6 @@ import (
 	"github.com/quorumcontrol/storage"
 )
 
-var trueByte = []byte{byte(1)}
-
 // StorageBasedStore is a NodeStore that can take an arbitrary storage back end
 type StorageBasedStore struct {
 	store  storage.Storage
@@ -107,7 +105,7 @@ func (sbs *StorageBasedStore) Resolve(tip cid.Cid, path []string) (val interface
 			// try resolving less of the path to find the existing boundary
 			var err error
 			for i := 1; i < len(path); i++ {
-				val, remaining, err = node.Resolve(path[:len(path)-i])
+				val, _, err = node.Resolve(path[:len(path)-i])
 				if err != nil {
 					continue
 				} else {
@@ -122,9 +120,9 @@ func (sbs *StorageBasedStore) Resolve(tip cid.Cid, path []string) (val interface
 		return nil, nil, err
 	}
 
-	switch val.(type) {
+	switch val := val.(type) {
 	case *format.Link:
-		linkNode, err := sbs.GetNode(val.(*format.Link).Cid)
+		linkNode, err := sbs.GetNode(val.Cid)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error getting linked node (%s): %v", linkNode.Cid().String(), err)
 		}

--- a/typecaster/typecaster.go
+++ b/typecaster/typecaster.go
@@ -1,10 +1,11 @@
 package typecaster
 
 import (
-	"github.com/polydawn/refmt/obj/atlas"
-	"github.com/polydawn/refmt/obj"
-	"github.com/polydawn/refmt/shared"
 	"sync"
+
+	"github.com/polydawn/refmt/obj"
+	"github.com/polydawn/refmt/obj/atlas"
+	"github.com/polydawn/refmt/shared"
 )
 
 var currentAtlas atlas.Atlas
@@ -36,7 +37,7 @@ func NewTyper(atl atlas.Atlas) Typer {
 		marshaller:   obj.NewMarshaller(atl),
 		unmarshaller: obj.NewUnmarshaller(atl),
 	}
-	x.pump = shared.TokenPump{x.marshaller, x.unmarshaller}
+	x.pump = shared.TokenPump{TokenSource: x.marshaller, TokenSink: x.unmarshaller}
 	return x
 }
 
@@ -47,7 +48,11 @@ type typer struct {
 }
 
 func (c typer) ToType(src, dst interface{}) error {
-	c.marshaller.Bind(src)
-	c.unmarshaller.Bind(dst)
+	if err := c.marshaller.Bind(src); err != nil {
+		return err
+	}
+	if err := c.unmarshaller.Bind(dst); err != nil {
+		return err
+	}
 	return c.pump.Run()
 }


### PR DESCRIPTION
Fix linting issues, as found by running `golangci-lint run`. We might want to hold off on merging this though until it's tested in integration with Tupelo, as it has stricter error checking and might uncover previously ignored errors.