### PR TITLE
Add dag.NodesForPath func

### DIFF
--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -3,11 +3,12 @@ package dag
 import (
 	"testing"
 
-	"github.com/quorumcontrol/chaintree/nodestore"
-	"github.com/quorumcontrol/chaintree/safewrap"
 	"github.com/quorumcontrol/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/chaintree/safewrap"
 )
 
 func newDeepDag(t *testing.T) *Dag {
@@ -36,6 +37,17 @@ func TestDagResolve(t *testing.T) {
 	require.Nil(t, err)
 	assert.Len(t, remain, 0)
 	assert.Equal(t, true, val)
+}
+
+func TestDagNodesForPath(t *testing.T) {
+	dag := newDeepDag(t)
+	nodes, err := dag.NodesForPath([]string{"child", "deepChild"})
+	require.Nil(t, err)
+	assert.Len(t, nodes, 3)
+	allNodes, _ := dag.Nodes()
+	for i, node := range allNodes {
+		assert.Equal(t, node.RawData(), nodes[i].RawData())
+	}
 }
 
 func TestDagSet(t *testing.T) {


### PR DESCRIPTION
This is in support of send/receive token. We need to send the nodes from tip to send coin transaction, and this allows more efficient retrieval of them than what I started with using the pre-existing API.

And it may also be useful in other places where we only need nodes along a given path (vs. all nodes which we use [in places](https://github.com/quorumcontrol/tupelo-go-client/blob/master/client/client.go#L164) for now).