### PR TITLE
Re-implement clobber detection logic

### DIFF
--- a/chaintree/chaintree_test.go
+++ b/chaintree/chaintree_test.go
@@ -483,5 +483,4 @@ func BenchmarkEncodeDecode(b *testing.B) {
 		_, _, err = chainTree.Dag.Resolve([]string{"tree", "down", "in", "the", "thing"})
 	}
 	require.Nil(b, err)
-
 }


### PR DESCRIPTION
Re-introduce the clobber detection logic, since the previous implementation caused bugs as discovered by @tobowers, and got backed out. I think this iteration of the logic makes sense, but please provide feedback :)

Solves [this](https://trello.com/c/rHloRxYM/110-return-an-error-to-the-client-if-they-attempt-to-set-complex-nested-data-where-a-simple-value-already-exists) card.