### PR TITLE
Add method Dag.ResolveAt

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -70,14 +70,21 @@ func (d *Dag) CreateNode(obj interface{}) (*cbornode.Node, error) {
 	return d.store.CreateNode(obj)
 }
 
-// Resolve takes a path (as a string slice) and returns the value, remaining path and any error
-// it delegates to the underlying store's resolve
+// Resolve takes a path (as a string slice) and returns the value, remaining path and any error.
+// It delegates to the underlying store's resolve.
 func (d *Dag) Resolve(path []string) (interface{}, []string, error) {
 	return d.store.Resolve(d.Tip, path)
 }
 
+// ResolveAt takes a tip and a path (as a string slice) and returns the value, remaining path
+// and any error.
+// It delegates to the underlying store's resolve.
+func (d *Dag) ResolveAt(tip cid.Cid, path []string) (interface{}, []string, error) {
+	return d.store.Resolve(tip, path)
+}
+
 func (d *Dag) NodesForPath(path []string) ([]*cbornode.Node, error) {
-	nodes := make([]*cbornode.Node, len(path) + 1) // + 1 for tip node
+	nodes := make([]*cbornode.Node, len(path)+1) // + 1 for tip node
 
 	tipNode, err := d.Get(d.Tip)
 	if err != nil {
@@ -102,7 +109,7 @@ func (d *Dag) NodesForPath(path []string) ([]*cbornode.Node, error) {
 			return nil, err
 		}
 
-		nodes[i + 1] = cur
+		nodes[i+1] = cur
 	}
 
 	return nodes, nil

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -39,6 +39,25 @@ func TestDagResolve(t *testing.T) {
 	assert.Equal(t, true, val)
 }
 
+// Test that the ResolveAt method can operate with a tip that need not be current.
+func TestDagResolveAt(t *testing.T) {
+	dag := newDeepDag(t)
+	oldTip := dag.Tip
+	dag, err := dag.Set([]string{"child", "value"}, true)
+	require.Nil(t, err)
+
+	val, remain, err := dag.ResolveAt(oldTip, []string{"child", "deepChild", "deepChild"})
+	require.Nil(t, err)
+	require.Len(t, remain, 0)
+	require.Equal(t, true, val)
+
+	missingVal, remain, err := dag.ResolveAt(oldTip, []string{"child", "value"})
+	require.Nil(t, err)
+	require.Len(t, remain, 1)
+	require.Equal(t, remain, []string{"value"})
+	require.Nil(t, missingVal)
+}
+
 func TestDagNodesForPath(t *testing.T) {
 	dag := newDeepDag(t)
 	nodes, err := dag.NodesForPath([]string{"child", "deepChild"})


### PR DESCRIPTION
Add method `Dag.ResolveAt`, which is like `Dag.Resolve`, but allows specifying the tip.

Part of solving [this card](https://trello.com/c/AoF2wzPg/138-js-client-should-be-able-to-resolve-data-at-tip-rather-than-just-chain-id).