### PR TITLE
Add exported func for getting the tree w/o chain

### DIFF
--- a/chaintree/chaintree.go
+++ b/chaintree/chaintree.go
@@ -141,10 +141,10 @@ func (ct *ChainTree) Id() (string, error) {
 func (ct *ChainTree) Tree() (*dag.Dag, error) {
 	root, err := ct.getRoot()
 	if err != nil {
-		return nil, err
+		return nil, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error getting root node: %v", err.Error())}
 	}
 	if root.Tree == nil {
-		return nil, fmt.Errorf("tree link is nil")
+		return nil, &ErrorCode{Code: ErrInvalidTree, Memo: "tree link is nil"}
 	}
 	return ct.Dag.WithNewTip(*root.Tree), nil
 }


### PR DESCRIPTION
This is useful when you have code that only cares about / operates on trees and you have a chaintree you'd like to pass to it.

I kept running into a need for this while working on receive coin b/c TreeLedger (normally called from transaction funcs that only get the tree anyway) only operates on trees and the paths were breaking when I tried to use them in other contexts where I had the whole chaintree (e.g. in tests) due to the leading `tree` element.