### PR TITLE
minor perf improvement on dag node lookup

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -174,6 +174,10 @@ func (d *Dag) nodeAndDescendants(node *cbornode.Node, collector NodeMap) error {
 
 	links := node.Links()
 	for _, link := range links {
+		_, ok := collector[link.Cid]
+		if ok {
+			continue
+		}
 		linkNode, err := d.store.GetNode(link.Cid)
 		if err != nil {
 			return fmt.Errorf("error getting link: %v", err)


### PR DESCRIPTION
@brandonwestcott had already improved this a lot to not return duplicate nodes. This just builds on that to not even get the node and do any processing,etc if we already have the node in the collector.