### PR TITLE
allow setting the cache size

### DIFF
--- a/cachedblockstore/cached.go
+++ b/cachedblockstore/cached.go
@@ -13,8 +13,8 @@ type CachedBlockstore struct {
 	cache *lru.Cache
 }
 
-func WrapInCache(bs blockstore.Blockstore) (*CachedBlockstore, error) {
-	cache, err := lru.New(10000)
+func WrapInCache(bs blockstore.Blockstore, size int) (*CachedBlockstore, error) {
+	cache, err := lru.New(size)
 	if err != nil {
 		return nil, xerrors.Errorf("error creating cache: %w", err)
 	}

--- a/cachedblockstore/cached_test.go
+++ b/cachedblockstore/cached_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetWhenKeyNotPresent(t *testing.T) {
 	underlying := blockstore.NewBlockstore(dsync.MutexWrap(ds.NewMapDatastore()))
-	bs, err := WrapInCache(underlying)
+	bs, err := WrapInCache(underlying, 100)
 	if err != nil {
 		t.Error(err)
 	}
@@ -34,7 +34,7 @@ func TestGetWhenKeyNotPresent(t *testing.T) {
 
 func TestGetWhenKeyIsNil(t *testing.T) {
 	underlying := blockstore.NewBlockstore(dsync.MutexWrap(ds.NewMapDatastore()))
-	bs, err := WrapInCache(underlying)
+	bs, err := WrapInCache(underlying, 100)
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func TestGetWhenKeyIsNil(t *testing.T) {
 
 func TestPutThenGetBlock(t *testing.T) {
 	underlying := blockstore.NewBlockstore(dsync.MutexWrap(ds.NewMapDatastore()))
-	bs, err := WrapInCache(underlying)
+	bs, err := WrapInCache(underlying, 100)
 	if err != nil {
 		t.Error(err)
 	}

--- a/nodestore/datastorebased.go
+++ b/nodestore/datastorebased.go
@@ -30,13 +30,13 @@ func MustMemoryStore(ctx context.Context) DagStore {
 	return ds
 }
 
-func FromDatastoreOfflineCached(ctx context.Context, ds datastore.Batching) (DagStore, error) {
-	bs := blockstoreFromDatastore(ds, true)
+func FromDatastoreOfflineCached(ctx context.Context, ds datastore.Batching, cachesize int) (DagStore, error) {
+	bs := blockstoreFromDatastore(ds, cachesize)
 	return dagstoreFromBlockstore(bs), nil
 }
 
 func FromDatastoreOffline(ctx context.Context, ds datastore.Batching) (DagStore, error) {
-	bs := blockstoreFromDatastore(ds, false)
+	bs := blockstoreFromDatastore(ds, -1)
 	return dagstoreFromBlockstore(bs), nil
 }
 
@@ -48,11 +48,11 @@ func dagstoreFromBlockstore(bs blockstore.Blockstore) DagStore {
 	return merkledag.NewDAGService(bserv)
 }
 
-func blockstoreFromDatastore(ds datastore.Batching, cached bool) blockstore.Blockstore {
+func blockstoreFromDatastore(ds datastore.Batching, cachesize int) blockstore.Blockstore {
 	bs := blockstore.NewBlockstore(ds)
 	bs = blockstore.NewIdStore(bs)
-	if cached {
-		wrapped, err := cachedblockstore.WrapInCache(bs)
+	if cachesize > 0 {
+		wrapped, err := cachedblockstore.WrapInCache(bs, cachesize)
 		if err != nil {
 			panic(err) // this only fails if for some reason the lru didn't initalize, which doesn't happen
 		}

--- a/nodestore/datastorebased_test.go
+++ b/nodestore/datastorebased_test.go
@@ -24,7 +24,7 @@ func TestFromDatastoreOfflineCached(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	store := dsync.MutexWrap(datastore.NewMapDatastore())
-	ds, err := FromDatastoreOfflineCached(ctx, store)
+	ds, err := FromDatastoreOfflineCached(ctx, store, 100)
 	require.Nil(t, err)
 	require.NotNil(t, ds)
 }


### PR DESCRIPTION
oops - 10000 can easily be 10GB as blocks can be 1MB or larger, this allows you to set the cache size for the blockstore.