### PR TITLE
return the same type of block as the blockstore does on a cache hit

### DIFF
--- a/cachedblockstore/cached.go
+++ b/cachedblockstore/cached.go
@@ -32,7 +32,8 @@ func (cbs *CachedBlockstore) DeleteBlock(id cid.Cid) error {
 func (cbs *CachedBlockstore) Get(id cid.Cid) (blocks.Block, error) {
 	blckInter, ok := cbs.cache.Get(id)
 	if ok {
-		return blckInter.(blocks.Block), nil
+		blk := blckInter.(blocks.Block)
+		return blocks.NewBlockWithCid(blk.RawData(), blk.Cid())
 	}
 	blk, err := cbs.Blockstore.Get(id)
 	if err == nil {


### PR DESCRIPTION
So, unfortunately, i don't know why this works :(. I noticed that the cache hit was causing the game failure at torch. I also noticed that the types of the blocks.Block being returned were different. The cache has a cbornode and the blockstore had a simple block... this has the cache just return the same type and magically the game works again.