### PR TITLE
decode handling

### DIFF
--- a/safewrap/safewrap_test.go
+++ b/safewrap/safewrap_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	cid "github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	multihash "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,4 +52,30 @@ func TestSafeWrap_WrapObject(t *testing.T) {
 	wrappedCbor := sw.WrapObject(cbor)
 	require.Nil(t, sw.Err)
 	assert.Equal(t, cbor, wrappedCbor)
+}
+
+func TestSafeWrap_Decode(t *testing.T) {
+	sw := &SafeWrap{}
+
+	for _, test := range []struct {
+		description string
+		obj         interface{}
+	}{
+		{
+			description: "an object with an empty cid",
+			obj:         &objWithNilPointers{Other: "something"},
+		},
+		{
+			description: "a large uint64",
+			obj:         uint64(12348347582345823458),
+		},
+	} {
+		node := sw.WrapObject(test.obj)
+		require.Nil(t, sw.Err)
+
+		new := sw.Decode(node.RawData())
+		assert.Nil(t, sw.Err, test.description)
+		assert.True(t, node.Cid().Equals(new.Cid()))
+	}
+
 }


### PR DESCRIPTION
This is a doozy to explain well...

https://github.com/ipfs/go-ipld-cbor/blob/master/node.go#L95 is what we used to use in SafeWrap. When we upgraded refmt, refmt changed its handling of uint64 to, instead, drop it into an int (which overflows). So here: that uint64 gets converted into an overflowed int, and then it gets remarshaled here: https://github.com/ipfs/go-ipld-cbor/blob/master/node.go#L103 causing the CID and bytes to be different.

This was causing a bug in monetary policy which is a uint64 being large, which then caused the CID to be different, which then makes the chaintree lose some of its nodes when it's processing a transaction.

This fixes it so calling sw.Decode will do the right thing, but we have to keep in mind that calling `cbornode.Decode` is now a dangerous act in our codebase.