### PR TITLE
allow using a new store on the dag

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -65,6 +65,13 @@ func (d *Dag) WithNewTip(tip cid.Cid) *Dag {
 	}
 }
 
+func (d *Dag) WithNewStore(store nodestore.DagStore) *Dag {
+	return &Dag{
+		Tip:   d.Tip,
+		store: store,
+	}
+}
+
 // Get takes a CID and returns the cbornode
 func (d *Dag) Get(ctx context.Context, id cid.Cid) (format.Node, error) {
 	n, err := d.store.Get(ctx, id)

--- a/dag/dag_test.go
+++ b/dag/dag_test.go
@@ -150,6 +150,16 @@ func TestDagResolve(t *testing.T) {
 	assert.Equal(t, true, val)
 }
 
+func TestDagWithNewStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dag := newDeepDag(t, ctx)
+	newStore := nodestore.MustMemoryStore(ctx)
+	newDag := dag.WithNewStore(newStore)
+	require.Equal(t, newStore, newDag.store)
+	require.Equal(t, dag.Tip.String(), newDag.Tip.String())
+}
+
 // Test that the ResolveAt method can operate with a tip that need not be current.
 func TestDagResolveAt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
I'm going to use this in the tupelo-go-sdk to swap out the store for a wrapped one that keeps track of Gets... to slim down Tx sizes.