### PR TITLE
Add ChainTree.Nodes for fetching all non-grafted nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,4 +32,5 @@ require (
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
+	google.golang.org/appengine v1.4.0 // indirect
 )


### PR DESCRIPTION
So, i keep going back and forth on where and how to implement this, but I do think it _is_ useful.

This exposes a `ChainTree.Nodes()` in addition to `ChainTree.Dag.Nodes` which returns all non-grafted noes of the current `ChainTree`. Essentially if the iterator sees a `RootNode` that has a mismatched `Id`, then its considered an grafted cid and it and all its children get ignore.

I'm actually kind of leaning toward keeping the `Dag.FilteredNodes()` here, but then moving the "this chaintree's nodes" into `consensus.SignedChainTree` since we are then dealing with and explicit tupelo ChainTree, which would allow better filtering on `did:tupelo:` to ensure its not pruning "root-like" nodes.