### PR TITLE
Fix graftable resolve cases where slice has only one element

### DIFF
--- a/graftabledag/graftabledag.go
+++ b/graftabledag/graftabledag.go
@@ -89,9 +89,12 @@ func (gd *GraftedDag) resolveRecursively(ctx context.Context, path chaintree.Pat
 
 	didPaths := make([]chaintree.Path, 0)
 	values := make([]interface{}, 0)
+	returnSingle := false
 
 	switch v := value.(type) {
 	case string:
+		returnSingle = true
+
 		if strings.HasPrefix(v, "did:tupelo:") {
 			didPath := strings.Split(v, "/")
 			didPaths = append(didPaths, didPath)
@@ -111,6 +114,8 @@ func (gd *GraftedDag) resolveRecursively(ctx context.Context, path chaintree.Pat
 				values = append(values, val)
 			}
 		}
+	case nil:
+		// noop
 	default:
 		values = append(values, v)
 	}
@@ -143,10 +148,10 @@ func (gd *GraftedDag) resolveRecursively(ctx context.Context, path chaintree.Pat
 		values = append(values, value)
 	}
 
-	switch len(values) {
-	case 1:
+	switch {
+	case returnSingle:
 		value = values[0]
-	case 0:
+	case len(values) == 0:
 		value = nil
 	default:
 		value = values

--- a/graftabledag/graftabledag_test.go
+++ b/graftabledag/graftabledag_test.go
@@ -204,7 +204,7 @@ func TestGraftedDag_GlobalResolve(t *testing.T) {
 	val, remaining, err := gd.GlobalResolve(ctx, path)
 	require.Nil(t, err)
 	require.Empty(t, remaining)
-	assert.Equal(t, val, []interface{}{true})
+	assert.Equal(t, val, true)
 }
 
 func TestGraftedDag_GlobalResolve_LoopDetection(t *testing.T) {

--- a/graftabledag/graftabledag_test.go
+++ b/graftabledag/graftabledag_test.go
@@ -204,10 +204,7 @@ func TestGraftedDag_GlobalResolve(t *testing.T) {
 	val, remaining, err := gd.GlobalResolve(ctx, path)
 	require.Nil(t, err)
 	require.Empty(t, remaining)
-
-	v, ok := val.(bool)
-	assert.True(t, ok)
-	assert.True(t, v)
+	assert.Equal(t, val, []interface{}{true})
 }
 
 func TestGraftedDag_GlobalResolve_LoopDetection(t *testing.T) {


### PR DESCRIPTION
So to be honest, I'm not 100% sure this is correct 😄  - it took me a bit to track down and reason about this, but my reasoning could be off, the coffee has worn off....

In implementing on dgit, I was getting:
```
error creating NewAddBlockRequest: error processing block (valid: false): 0 - error resolving owners: got unexpected type for auths 0x898E6985F1C5b62eAd19Faf7703E0612ddB06eA0: string
```

That's from a `SetDataTransaction` on an existing ChainTree that has a single address in `_authentications`.

So I added a var, that determines the single / multi return based on the original resolve. That then cause a bug with returning a slice of nils, so added that as well.